### PR TITLE
Update ArticleRepository.php

### DIFF
--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -16,10 +16,10 @@ class ArticleRepository
             ->get();
     }
 
-    public static function findBySlug(string $url): Article
+    public static function findBySlug(string $slug): Article
     {
         $article = Article::online()
-            ->where('url->'.content_locale(), $url)
+            ->where('slug->'.content_locale(), $slug)
             ->first();
 
         abort_unless($article, 404);


### PR DESCRIPTION
Column 'url' not found in table. This column was changed to 'slug' in the migration. Updated to reflect this change.