### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-  - travis_retry composer self-update
   - composer install --prefer-dist --ignore-platform-reqs
   - nvm install node
   - npm install -g yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-  - pecl install imagick -y
   - travis_retry composer self-update
-  - composer install --prefer-dist
+  - composer install --prefer-dist --ignore-platform-reqs
   - nvm install node
   - npm install -g yarn
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-  - pecl install imagick
+  - pecl install imagick -y
   - travis_retry composer self-update
   - composer install --prefer-dist
   - nvm install node

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
+  - pecl install imagick
   - travis_retry composer self-update
   - composer install --prefer-dist
   - nvm install node


### PR DESCRIPTION
- Ignore platform requirements so we can run composer without Imagick (the tests don't need it anyway)
- Remove `composer self-update`, since Travis already does it for us