### PR TITLE
Enumerator interface as contract

### DIFF
--- a/app/Models/Enums/Enumerator.php
+++ b/app/Models/Enums/Enumerator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Enums;
+
+/**
+ * Interface Enumerator
+ *
+ * @package App\Models\Enums;
+ */
+interface Enumerator
+{
+    /**
+     * @return array
+     */
+    public static function __toArray(): array;
+}

--- a/app/Models/Enums/Enumerator.php
+++ b/app/Models/Enums/Enumerator.php
@@ -2,11 +2,6 @@
 
 namespace App\Models\Enums;
 
-/**
- * Interface Enumerator
- *
- * @package App\Models\Enums;
- */
 interface Enumerator
 {
     /**

--- a/app/Models/Enums/SpecialArticle.php
+++ b/app/Models/Enums/SpecialArticle.php
@@ -2,10 +2,11 @@
 
 namespace App\Models\Enums;
 
-class SpecialArticle implements Enumerators
+use ReflectionClass;
+
+class SpecialArticle implements Enumerator
 {
     const __default = self::HOME;
-    
     const HOME = 'home';
     const CONTACT = 'contact';
     

--- a/app/Models/Enums/SpecialArticle.php
+++ b/app/Models/Enums/SpecialArticle.php
@@ -2,8 +2,18 @@
 
 namespace App\Models\Enums;
 
-class SpecialArticle
+class SpecialArticle implements Enumerators
 {
+    const __default = self::HOME;
+    
     const HOME = 'home';
     const CONTACT = 'contact';
+    
+     /**
+     * @return array
+     */
+    public static function __toArray(): array
+    {
+        return (new ReflectionClass(get_class()))->getConstants();
+    }
 }

--- a/tests/Unit/SpecialArticleTest.php
+++ b/tests/Unit/SpecialArticleTest.php
@@ -4,11 +4,6 @@ namespace Tests\Unit;
 
 use App\Models\Enums\SpecialArticle;
 
-/**
- * Class SpecialArticleTest
- * 
- * @package Tests\Unit
- */
 class SpecialArticleTest extends TestCase
 {
     /** @test */

--- a/tests/Unit/SpecialArticleTest.php
+++ b/tests/Unit/SpecialArticleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Enums\SpecialArticle;
+
+/**
+ * Class SpecialArticleTest
+ * 
+ * @package Tests\Unit
+ */
+class SpecialArticleTest extends TestCase
+{
+    /** @test */
+    public function it_retrieves_the_default_value()
+    {
+        $this->assertEquals('home', SpecialArticle::__default);
+    }
+    
+    /** @test */
+    public function it_returns_an_array_of_values()
+    {
+        $this->assertTrue(is_array(SpecialArticle::__toArray()));
+    }
+}


### PR DESCRIPTION
Hello  

I would like to propose this changes for Blender as my first contribution to this project, which I find interesting.

## What is all about ?

This is the first implementation for a structure that allows enumerators to exists like in other programming languages such as c# or elixir. 

The main goal is to provide a common layer for every future enumerators in order to use the same API across all the application.

## Why matters ?

PHP does not have a good enumerator implementation. [There](https://stackoverflow.com/questions/254514/php-and-enumerations) [are](https://github.com/myclabs/php-enum) [a](https://github.com/marc-mabe/php-enum) [lot](https://github.com/eloquent/enumeration) [of](http://www.dreamincode.net/forums/topic/201638-enum-in-php/) [implementations](https://www.codeproject.com/articles/683009/enum-support-in-php) of it but either they are old or they have been implemented in a weird way, without even tests.

## Why bothering create a new one? 

Enumerator are powerful and they need to be implemented with the best standard possible. I'm referring myself to .NET and Elixir in particular

# Tasks

- [x] Add the ability to each enumerator to return an array of values that represent all the possible values of the enumerator itself.
- [x] Add some backup test for the initial implementation of this feature
- [x] Add new constant called `_default` that will retrieve the default value for the specific operator
- [ ] Improve the Enumerator interface in order to create a robust contract between the concrete classes