### PR TITLE
Tags method doesn't render multiple selected tags

### DIFF
--- a/app/Services/Html/Concerns/Forms.php
+++ b/app/Services/Html/Concerns/Forms.php
@@ -50,8 +50,10 @@ trait Forms
     }
 
     public function tags(string $type): Select
-    {
-        return $this->category($type)->attributes(['multiple', 'data-select' => 'tags']);
+    {        
+        return $this->category($type)
+            ->attributes(['multiple', 'data-select' => 'tags'])
+            ->value($this->model->tagsWithType($type)->pluck('name', 'name'));
     }
 
     public function searchableSelect(string $name = '', iterable $options = [], ? string $value = '')


### PR DESCRIPTION
Adding the `multiple` attribute on the category `<select>` doesn't re-evaluate the selected values and thus only reders one `<option>` as selected. 
Setting the value again after the attribute was added triggers `applyValueToOptions` and renders multiple selected `<option>`s.

An alternative fix would be the following:
```php
    public function tags(string $type): Select
    {
        $this->ensureModelIsAvailable();

        return $this->multiselect(
            "{$type}_tags[]",
            Tag::getWithType($type)->pluck('name', 'name'),
            $this->model->tagsWithType($type)->pluck('name', 'name')
        )
            ->attribute('data-select', 'tags');
    }
```