### PR TITLE
Added multiselect form field for associated models

### DIFF
--- a/app/Services/Html/Concerns/Forms.php
+++ b/app/Services/Html/Concerns/Forms.php
@@ -56,7 +56,7 @@ trait Forms
             ->value($this->model->tagsWithType($type)->pluck('name', 'name'));
     }
 
-    public function associatedModelsSelect(string $name, string $nameProperty = 'name', ?iterable $options = null)
+    public function relatedModelsSelect(string $name, string $nameProperty = 'name', ?iterable $options = null)
     {
         $this->ensureModelIsAvailable();
 

--- a/app/Services/Html/Concerns/Forms.php
+++ b/app/Services/Html/Concerns/Forms.php
@@ -56,6 +56,24 @@ trait Forms
             ->value($this->model->tagsWithType($type)->pluck('name', 'name'));
     }
 
+    public function associatedModelsSelect(string $name, string $nameProperty = 'name', ?iterable $options = null)
+    {
+        $this->ensureModelIsAvailable();
+
+        $relatedModel = $this->model->{$name}()->getRelated();
+
+        $options = $options ?? $relatedModel->get()->pluck($nameProperty, 'id');
+
+        $selectedOptions = $this->model->{$name} ?? collect();
+
+        return $this->multiselect(
+            "{$name}[]",
+            $options,
+            $selectedOptions->pluck('id')
+        )
+            ->attribute('data-select', 'tags');
+    }
+
     public function searchableSelect(string $name = '', iterable $options = [], ? string $value = '')
     {
         return $this->select($name, $options, $value)->attribute('data-select', 'search');

--- a/app/Services/Html/FormGroup.php
+++ b/app/Services/Html/FormGroup.php
@@ -70,6 +70,11 @@ class FormGroup
         return $this->assemble($collection, $label, $this->html->media($collection, $type, $associated));
     }
 
+    public function associatedModelsSelect(string $name, string $label, string $nameProperty = 'name', ?iterable $models = null): Div
+    {
+        return $this->assemble($name, $label, $this->html->associatedModelsSelect($name, $nameProperty, $models));
+    }
+
     public function password(string $name, string $label): Div
     {
         return $this->assemble($name, $label, $this->html->password($name));

--- a/app/Services/Html/FormGroup.php
+++ b/app/Services/Html/FormGroup.php
@@ -70,7 +70,7 @@ class FormGroup
         return $this->assemble($collection, $label, $this->html->media($collection, $type, $associated));
     }
 
-    public function associatedModelsSelect(string $name, string $label, string $nameProperty = 'name', ?iterable $models = null): Div
+    public function relatedModelsSelect(string $name, string $label, string $nameProperty = 'name', ?iterable $models = null): Div
     {
         return $this->assemble($name, $label, $this->html->associatedModelsSelect($name, $nameProperty, $models));
     }


### PR DESCRIPTION
`associatedModelsSelect` will build a multiselect form field based on a relation on the `form`'s model.

For example: 
```php
{{ html()->modelForm($user, 'POST')->open() }}

    {{ html()->formGroup()->associatedModelsSelect('projects', 'Associated projects');

{{ html()->closeModelForm() }}
```
This will build a form for the user model with a multiselect element containing all `Project`s as options and automatically select any already associated projects.

You can also specify a custom collection of options and the name of the property used for the `<option>` labels:
```php
{{ html()->modelForm($user, 'POST')->open() }}

    {{ html()->formGroup()->associatedModelsSelect('projects', 'Associated projects', Project::active()->get(), 'title');

{{ html()->closeModelForm() }}
```