### PR TITLE
Fix content blocks error on new record creation

### DIFF
--- a/app/Http/Controllers/Back/Api/ContentBlockController.php
+++ b/app/Http/Controllers/Back/Api/ContentBlockController.php
@@ -26,7 +26,15 @@ class ContentBlockController extends Controller
 
     protected function getModelFromRequest($request): Model
     {
-        return call_user_func($request['model_name'].'::findOrFail', $request['model_id']);
+        if (! isset($request['model_name'])) {
+            throw new Exception('No model name provided');
+        }
+
+        if (! isset($request['model_id'])) {
+            throw new Exception('No model id provided');
+        }
+
+        return $request['model_name']::withoutGlobalScopes()->findOrFail($request['model_id']);
     }
 
     protected function validationRules(): array

--- a/app/Http/Controllers/Back/Api/ContentBlockController.php
+++ b/app/Http/Controllers/Back/Api/ContentBlockController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Back\Api;
 
-use Exception;
 use App\Http\Controllers\Controller;
 use App\Models\ContentBlock;
 use App\Models\Transformers\ContentBlockTransformer;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;

--- a/app/Http/Controllers/Back/Api/ContentBlockController.php
+++ b/app/Http/Controllers/Back/Api/ContentBlockController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Back\Api;
 
+use Exception;
 use App\Http\Controllers\Controller;
 use App\Models\ContentBlock;
 use App\Models\Transformers\ContentBlockTransformer;

--- a/app/Models/ContentBlock.php
+++ b/app/Models/ContentBlock.php
@@ -24,7 +24,7 @@ class ContentBlock extends Model implements HasMediaConversions
 
     public function subject(): MorphTo
     {
-        return $this->morphTo('model');
+        return $this->morphTo('model')->withoutGlobalScopes();
     }
 
     public function registerMediaConversions(Media $media = null)


### PR DESCRIPTION
Steps to reproduce:

- Create a new article and try to add a new content block while keeping the console open, you will notice the error.

- Since by default draft scope is true, it can't find an article to attach the block to.