### PR TITLE
Automatically detect HTML fragments when importing

### DIFF
--- a/app/Console/Commands/ImportFragments.php
+++ b/app/Console/Commands/ImportFragments.php
@@ -45,12 +45,23 @@ class ImportFragments extends Command
                 $fragment->setTranslation($locale, $text ?: '');
             }
 
-            $fragment->html = $attributes['html'] ?? false;
+            $fragment->html = $attributes['html'] ?? $this->translationsContainHtml($translations);
             $fragment->description = $attributes['description'] ?? null;
 
             $fragment->save();
 
             return $fragment;
         })->values();
+    }
+
+    private function translationsContainHtml(array $translations): bool
+    {
+        foreach ($translations as $translation) {
+            if ($translation != strip_tags($translation)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Console/Commands/ImportFragments.php
+++ b/app/Console/Commands/ImportFragments.php
@@ -57,7 +57,7 @@ class ImportFragments extends Command
     private function translationsContainHtml(array $translations): bool
     {
         foreach ($translations as $translation) {
-            if ($translation != strip_tags($translation)) {
+            if ((string) $translation !== strip_tags($translation)) {
                 return true;
             }
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -57,6 +57,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        'logRequest' => \Spatie\HttpLogger\Middlewares\HttpLogger::class
+        'logRequest' => \Spatie\HttpLogger\Middlewares\HttpLogger::class,
     ];
 }


### PR DESCRIPTION
Great idea by @willemvb. 

Fragment importer will automatically detect HTML fragments and set the `html` flag. This can still be overridden by manually setting the `html` property to the fragment yml file.