### PR TITLE
Default to .test TLD in .env example files

### DIFF
--- a/.env.dusk.local
+++ b/.env.dusk.local
@@ -2,7 +2,7 @@ APP_ENV=testing
 APP_DEBUG=true
 APP_NAME=blender
 DEMO_MODE_ENABLED=false
-APP_URL=http://blender.dev
+APP_URL=http://blender.test
 APP_KEY=SomeRandomStringWith32Characters
 
 DB_CONNECTION=sqlite

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_NAME=blender
 DEMO_MODE_ENABLED=false
-APP_URL=http://blender.dev
+APP_URL=http://blender.test
 APP_KEY=SomeRandomStringWith32Characters
 
 COOKIE_CONSENT_ENABLED=false


### PR DESCRIPTION
With `.dev` not being used anymore, this might be a better sensible default?