### PR TITLE
Make OnlineScope work again

### DIFF
--- a/app/Models/Scopes/OnlineScope.php
+++ b/app/Models/Scopes/OnlineScope.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Scopes;
 
-use App\Models\Traits\Draftable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -11,7 +10,7 @@ class OnlineScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        if ($model instanceof Draftable) {
+        if (class_has_trait(get_class($model), 'App\Models\Traits\Draftable')) {
             $builder->where('online', true);
         }
     }

--- a/app/Models/Scopes/OnlineScope.php
+++ b/app/Models/Scopes/OnlineScope.php
@@ -2,10 +2,10 @@
 
 namespace App\Models\Scopes;
 
+use App\Models\Traits\Draftable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use App\Models\Traits\Draftable;
 
 class OnlineScope implements Scope
 {

--- a/app/Models/Scopes/OnlineScope.php
+++ b/app/Models/Scopes/OnlineScope.php
@@ -5,12 +5,13 @@ namespace App\Models\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use App\Models\Traits\Draftable;
 
 class OnlineScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        if (class_has_trait(get_class($model), 'App\Models\Traits\Draftable')) {
+        if (class_has_trait($model, Draftable::class)) {
             $builder->where('online', true);
         }
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -198,3 +198,8 @@ function validate($fields, $rules): bool
 
     return Validator::make($fields, $rules)->passes();
 }
+
+function class_has_trait(string $className, string $traitName): bool
+{
+    return in_array($traitName, class_uses_recursive($className));
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -199,7 +199,11 @@ function validate($fields, $rules): bool
     return Validator::make($fields, $rules)->passes();
 }
 
-function class_has_trait(string $className, string $traitName): bool
+function class_has_trait($className, string $traitName): bool
 {
+    if (is_object($className)) {
+        $className = get_class($className);
+    }
+
     return in_array($traitName, class_uses_recursive($className));
 }

--- a/tests/Unit/classHasTraitTest.php
+++ b/tests/Unit/classHasTraitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Unit;
+
+use App\Models\Traits\Draftable;
+use App\Models\Traits\HasMedia;
+use PHPUnit\Framework\TestCase;
+
+class classHasTraitTest extends TestCase
+{
+    /** @test */
+    public function it_knows_whether_a_class_has_a_trait_or_not()
+    {
+        $model = new class {
+            use Draftable;
+        };
+
+        $this->assertTrue(class_has_trait($model, Draftable::class));
+        $this->assertFalse(class_has_trait($model, HasMedia::class));
+    }
+}


### PR DESCRIPTION
I'm not sure about two things, so that's why I'm opening a PR.

- Laravel has the `class_uses_recursive` function, based on PHPs `class_uses` function. But there's not function to return a boolean whether a class uses a trait or not. However, adding this function to helpers might be overkill?
- As far as I know, there's no way to get the name of a trait like using `::class`. So that's why it's a hardcoded string. If there's another way to do this, I'd be happy to hear.