### PR TITLE
deployOnlyCode restart php7.2 instead of php7.1

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -166,7 +166,7 @@ git pull origin master
 php artisan config:clear
 php artisan cache:clear
 php artisan config:cache
-sudo service php7.1-fpm restart
+sudo service php7.2-fpm restart
 php artisan horizon:terminate
 sudo supervisorctl restart all
 @endtask


### PR DESCRIPTION
In commit 1bda170a58b8bc47c2c9fb6027333c61a8d0d214 freek updated to php7.2 but that's only changed in the "blessNewRelease" task.