### PR TITLE
The file `.env` must be created before installing dependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,13 @@ Download the master branch
 git clone https://github.com/spatie/blender.git
 ```
 
+Make a copy `.env.example` and rename to `.env`
+
 Install the composer dependencies
 
 ```bash
 composer install
 ```
-
-Make a copy `.env.example` and rename to `.env`
 
 Finally make sure you have a database named `blender`, and run the migrations and seeds
 


### PR DESCRIPTION
If I install dependencies without a file `.env`, I get an error:
```bash
Generating autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover

In DuskServiceProvider.php line 43:
                                           
  It is unsafe to run Dusk in production.  
                                           

Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```

Corrected the sequence in the documentation, the file `.env` must be created before installing dependencies.