### PR TITLE
update str and arr helpers to Str and Arr helpers for Laravel 5.8

### DIFF
--- a/app/Console/Commands/ImportFragments.php
+++ b/app/Console/Commands/ImportFragments.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Fragment;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Yaml\Yaml;
 
@@ -20,7 +21,7 @@ class ImportFragments extends Command
         $fragments = collect()->glob("{$root}/*.yml")->map(function (string $path) use ($root) {
             $fragments = Yaml::parse(file_get_contents($path));
 
-            $group = str_before(str_after($path, "{$root}/"), '.yml');
+            $group = Str::before(Str::after($path, "{$root}/"), '.yml');
 
             return $this->importFragmentGroup($group, $fragments);
         });

--- a/app/Http/Controllers/Back/Controller.php
+++ b/app/Http/Controllers/Back/Controller.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers\Back;
 
-use App\Models\Scopes\NonDraftScope;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Foundation\Validation\ValidatesRequests;
+use ReflectionClass;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use App\Models\Scopes\NonDraftScope;
 use Illuminate\Support\Facades\Cache;
-use ReflectionClass;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Foundation\Validation\ValidatesRequests;
 
 abstract class Controller
 {
@@ -127,7 +128,7 @@ abstract class Controller
 
     protected function determineModuleName(): string
     {
-        return lcfirst(str_replace_last('Controller', '', class_basename($this)));
+        return lcfirst(Str::replaceLast('Controller', '', class_basename($this)));
     }
 
     protected function updateModel(Eloquent $model, Request $request)

--- a/app/Http/Middleware/LoginAs.php
+++ b/app/Http/Middleware/LoginAs.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Middleware;
 
-use App\Services\Auth\Back\User as BackUser;
-use App\Services\Auth\Front\User as FrontUser;
 use Closure;
 use Exception;
+use Illuminate\Support\Str;
+use App\Services\Auth\Back\User as BackUser;
+use App\Services\Auth\Front\User as FrontUser;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class LoginAs
@@ -33,7 +34,7 @@ class LoginAs
             return false;
         }
 
-        if (! ends_with(request()->getHost(), '.dev')) {
+        if (! Str::endsWith(request()->getHost(), '.dev')) {
             return false;
         }
 
@@ -61,7 +62,7 @@ class LoginAs
 
     protected function getUser(string $identifier): Authenticatable
     {
-        if (! str_contains($identifier, '@')) {
+        if (! Str::contains($identifier, '@')) {
             $identifier .= '@spatie.be';
         }
 

--- a/app/Http/Middleware/RobotsMiddleware.php
+++ b/app/Http/Middleware/RobotsMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Spatie\RobotsMiddleware\RobotsMiddleware as BaseRobotsMiddleware;
 
@@ -9,7 +10,7 @@ class RobotsMiddleware extends BaseRobotsMiddleware
 {
     protected function shouldIndex(Request $request): bool
     {
-        if (ends_with($request->getHost(), 'spatie.be')) {
+        if (Str::endsWith($request->getHost(), 'spatie.be')) {
             return false;
         }
 

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -2,9 +2,10 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
-use Illuminate\Support\ServiceProvider;
 use Laravel\Horizon\Horizon;
+use Illuminate\Support\ServiceProvider;
 
 class HorizonServiceProvider extends ServiceProvider
 {
@@ -25,7 +26,7 @@ class HorizonServiceProvider extends ServiceProvider
                 return false;
             }
 
-            return ends_with($backUser->email, '@spatie.be');
+            return Str::endsWith($backUser->email, '@spatie.be');
         });
     }
 }

--- a/app/Services/Auth/Front/User.php
+++ b/app/Services/Auth/Front/User.php
@@ -2,13 +2,14 @@
 
 namespace App\Services\Auth\Front;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Mail;
+use App\Services\Auth\User as BaseUser;
 use App\Services\Auth\Front\Enums\UserRole;
 use App\Services\Auth\Front\Enums\UserStatus;
+use App\Services\Auth\Front\Mail\ResetPassword;
 use App\Services\Auth\Front\Events\UserRegistered;
 use App\Services\Auth\Front\Exceptions\UserIsAlreadyActivated;
-use App\Services\Auth\Front\Mail\ResetPassword;
-use App\Services\Auth\User as BaseUser;
-use Illuminate\Support\Facades\Mail;
 
 /**
  * @property string $address
@@ -30,7 +31,7 @@ class User extends BaseUser
             'status' => UserStatus::ACTIVE,
         ];
 
-        $user = static::create($defaults + array_only($input, [
+        $user = static::create($defaults + Arr::only($input, [
             'first_name',
             'last_name',
             'address',

--- a/app/Services/Auth/UserPresenter.php
+++ b/app/Services/Auth/UserPresenter.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Auth;
 
+use Illuminate\Support\Str;
+
 trait UserPresenter
 {
     public function getFullNameAttribute(): string
@@ -22,7 +24,7 @@ trait UserPresenter
 
         $lastActivityDate = diff_date_for_humans($this->last_activity);
 
-        if (str_contains($lastActivityDate, 'second')) {
+        if (Str::contains($lastActivityDate, 'second')) {
             $lastActivityDate = 'Just now';
         }
 

--- a/app/Services/Html/Concerns/Forms.php
+++ b/app/Services/Html/Concerns/Forms.php
@@ -2,16 +2,17 @@
 
 namespace App\Services\Html\Concerns;
 
-use App\Http\Resources\Media as MediaResource;
-use App\Models\ContentBlock;
 use App\Models\Tag;
-use App\Models\Transformers\ContentBlockTransformer;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use App\Models\ContentBlock;
 use Spatie\Html\Elements\Div;
-use Spatie\Html\Elements\Element;
 use Spatie\Html\Elements\Input;
 use Spatie\Html\Elements\Select;
+use Spatie\Html\Elements\Element;
+use Illuminate\Support\Collection;
 use Spatie\Html\Elements\Textarea;
+use App\Http\Resources\Media as MediaResource;
+use App\Models\Transformers\ContentBlockTransformer;
 
 trait Forms
 {
@@ -196,7 +197,7 @@ trait Forms
 
     protected function seoLabel(string $attribute): string
     {
-        if (starts_with($attribute, 'meta_')) {
+        if (Str::startsWith($attribute, 'meta_')) {
             return 'Meta: '.substr($attribute, 5);
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,16 +1,17 @@
 <?php
 
+use Carbon\Carbon;
 use App\Models\Article;
 use App\Models\Fragment;
 use App\Models\Recipient;
+use App\Services\Seo\Meta;
 use App\Services\Auth\User;
 use App\Services\Html\Html;
-use App\Services\Seo\Meta;
+use Illuminate\Support\Str;
 use App\Services\Seo\Schema;
-use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Facades\Validator;
 
 function article(string $specialArticle): Article
 {
@@ -47,7 +48,7 @@ function diff_date_for_humans(Carbon $date) : string
 
 function fragment_image($name, $conversion = 'thumb'): string
 {
-    if (! str_contains($name, '.')) {
+    if (! Str::contains($name, '.')) {
         return $name;
     }
 


### PR DESCRIPTION
Laravel 5.8 [deprecates the string and array helper functions](https://laravel.com/docs/master/upgrade#string-and-array-helpers) and each
use needs to be converted to the appropriate Str/Arr helper method to stay
compatible.